### PR TITLE
Update getOne method's return: remove '.data' property from returned api response.

### DIFF
--- a/backandService.ts
+++ b/backandService.ts
@@ -524,7 +524,7 @@ export class BackandService {
                 headers: this.authHeader
             })
             .retry(3)
-            .map(res => res.json().data);
+            .map(res => res.json());
     }
 
     public delete(object: string, id: string) {


### PR DESCRIPTION
It seems that the response from the Backand API doesn't return an object with a .data property, so this call was returning `undefined`. 